### PR TITLE
Fix HTML markup in software page

### DIFF
--- a/software.qmd
+++ b/software.qmd
@@ -12,11 +12,11 @@ section-divs: false
 import yaml
 from IPython.display import display, Markdown, HTML
 
-def button(url, str, icon):
+def button(url, label, icon):
     icon_base = icon[:2]
-    return f"""<a class="btn btn-outline-dark btn-sm", href="{url}" target="_blank" rel="noopener noreferrer">
-        <i class="{icon_base} {icon}" role='img' aria-label='{str}'></i>
-        {str}
+    return f"""<a class="btn btn-outline-dark btn-sm" href="{url}" target="_blank" rel="noopener noreferrer">
+        <i class="{icon_base} {icon}" role='img' aria-label='{label}'></i>
+        {label}
     </a>"""
 
 yaml_data = yaml.safe_load(open("software.yaml"))


### PR DESCRIPTION
## Summary
- fix comma in button HTML
- use a distinct label variable name

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import yaml
from IPython.display import HTML

def button(url, label, icon):
    icon_base = icon[:2]
    return f"""<a class="btn btn-outline-dark btn-sm" href="{url}" target="_blank" rel="noopener noreferrer">
        <i class="{icon_base} {icon}" role='img' aria-label='{label}'></i>
        {label}
    </a>"""
print(button('http://example.com', 'Example', 'bi-info'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685974b64ed08325beb1ef77917cff0a